### PR TITLE
better (non) nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## 1.0.0-dev2
 
 - simplify and optimize generated code
+- fix processor inside List/Map
+
+*** Breaking Changes ***
+- All Serializers are now nullable by default
+- Drop Map key processor
+- Only `Map<String, dynamic>` can be encode
+- `toMap(null)` return null
+- `fromMap(null)` return null
+- `fromMap({})` return object
 
 ## 1.0.0-dev1
 

--- a/example/basic/basic_main.g.dart
+++ b/example/basic/basic_main.g.dart
@@ -13,13 +13,13 @@ abstract class _$PlayerSerializer implements Serializer<Player> {
     Map<String, dynamic> ret;
     if (model != null) {
       ret = <String, dynamic>{};
-      setNonNullableValue(ret, "name", model.name);
-      setNonNullableValue(ret, "email", model.email);
-      setNonNullableValue(ret, "age", model.age);
-      setNonNullableValue(ret, "score", model.score);
-      setNonNullableValue(ret, "emailConfirmed", model.emailConfirmed);
-      setNonNullableValue(ret, "test", model.test);
-      setNonNullableValue(
+      setNullableValue(ret, "name", model.name);
+      setNullableValue(ret, "email", model.email);
+      setNullableValue(ret, "age", model.age);
+      setNullableValue(ret, "score", model.score);
+      setNullableValue(ret, "emailConfirmed", model.emailConfirmed);
+      setNullableValue(ret, "test", model.test);
+      setNullableValue(
           ret,
           "address",
           _addressSerializer.toMap(model.address,
@@ -55,10 +55,10 @@ abstract class _$AddressSerializer implements Serializer<Address> {
     Map<String, dynamic> ret;
     if (model != null) {
       ret = <String, dynamic>{};
-      setNonNullableValue(ret, "street", model.street);
-      setNonNullableValue(ret, "zipcode", model.zipcode);
-      setNonNullableValue(ret, "country", model.country);
-      setNonNullableValue(ret, "city", model.city);
+      setNullableValue(ret, "street", model.street);
+      setNullableValue(ret, "zipcode", model.zipcode);
+      setNullableValue(ret, "country", model.country);
+      setNullableValue(ret, "city", model.city);
       setTypeKeyValue(typeKey, modelString(), withType, ret);
     }
     return ret;

--- a/example/custom_field_processor/custom_field_processor.g.dart
+++ b/example/custom_field_processor/custom_field_processor.g.dart
@@ -13,9 +13,9 @@ abstract class _$PlayerMongoSerializer implements Serializer<Player> {
     Map<String, dynamic> ret;
     if (model != null) {
       ret = <String, dynamic>{};
-      setNonNullableValue(ret, "_id", _mongoId.serialize(model.id));
-      setNonNullableValue(ret, "name", model.name);
-      setNonNullableValue(ret, "email", model.email);
+      setNullableValue(ret, "_id", _mongoId.serialize(model.id));
+      setNullableValue(ret, "name", model.name);
+      setNullableValue(ret, "email", model.email);
       setTypeKeyValue(typeKey, modelString(), withType, ret);
     }
     return ret;

--- a/example/field_manipulation/field_manipulation_main.g.dart
+++ b/example/field_manipulation/field_manipulation_main.g.dart
@@ -11,10 +11,10 @@ abstract class _$PlayerJsonSerializer implements Serializer<Player> {
     Map<String, dynamic> ret;
     if (model != null) {
       ret = <String, dynamic>{};
-      setNonNullableValue(ret, "N", model.name);
-      setNonNullableValue(ret, "E", model.email);
-      setNonNullableValue(ret, "A", model.age);
-      setNonNullableValue(ret, "S", model.score);
+      setNullableValue(ret, "N", model.name);
+      setNullableValue(ret, "E", model.email);
+      setNullableValue(ret, "A", model.age);
+      setNullableValue(ret, "S", model.score);
       setTypeKeyValue(typeKey, modelString(), withType, ret);
     }
     return ret;

--- a/example/user/book/book.g.dart
+++ b/example/user/book/book.g.dart
@@ -11,9 +11,9 @@ abstract class _$BookViewSerializer implements Serializer<Book> {
     Map<String, dynamic> ret;
     if (model != null) {
       ret = <String, dynamic>{};
-      setNonNullableValue(ret, "id", model.id);
-      setNonNullableValue(ret, "name", model.name);
-      setNonNullableValue(ret, "publishedYear", model.publishedYear);
+      setNullableValue(ret, "id", model.id);
+      setNullableValue(ret, "name", model.name);
+      setNullableValue(ret, "publishedYear", model.publishedYear);
       setTypeKeyValue(typeKey, modelString(), withType, ret);
     }
     return ret;

--- a/example/user/book/book_mongo.g.dart
+++ b/example/user/book/book_mongo.g.dart
@@ -13,9 +13,9 @@ abstract class _$BookMongoSerializer implements Serializer<Book> {
     Map<String, dynamic> ret;
     if (model != null) {
       ret = <String, dynamic>{};
-      setNonNullableValue(ret, "_id", _mongoId.serialize(model.id));
-      setNonNullableValue(ret, "N", model.name);
-      setNonNullableValue(ret, "publishedYear", model.publishedYear);
+      setNullableValue(ret, "_id", _mongoId.serialize(model.id));
+      setNullableValue(ret, "N", model.name);
+      setNullableValue(ret, "publishedYear", model.publishedYear);
       setTypeKeyValue(typeKey, modelString(), withType, ret);
     }
     return ret;

--- a/example/user/user/user.g.dart
+++ b/example/user/user/user.g.dart
@@ -14,43 +14,38 @@ abstract class _$UserViewSerializer implements Serializer<User> {
     Map<String, dynamic> ret;
     if (model != null) {
       ret = <String, dynamic>{};
-      setNonNullableValue(ret, "Id", model.id);
-      setNonNullableValue(ret, "Email", model.email);
-      setNonNullableValue(ret, "N", model.name);
-      setNonNullableValue(ret, "DoB", _dateTimeSerializer.serialize(model.dob));
-      setNonNullableValue(
+      setNullableValue(ret, "Id", model.id);
+      setNullableValue(ret, "Email", model.email);
+      setNullableValue(ret, "N", model.name);
+      setNullableValue(ret, "DoB", _dateTimeSerializer.serialize(model.dob));
+      setNullableValue(
           ret,
           "Book",
           _bookViewSerializer.toMap(model.book,
               withType: withType, typeKey: typeKey));
-      setNonNullableValue(ret, "listStr",
-          safeIterableMapper<String>(model.listStr, (String val) => val));
-      setNonNullableValue(
+      setNullableValue(ret, "listStr",
+          nullableIterableMapper<String>(model.listStr, (String val) => val));
+      setNullableValue(
           ret,
           "listBook",
-          safeIterableMapper<Book>(
+          nullableIterableMapper<Book>(
               model.listBook,
               (Book val) => _bookViewSerializer.toMap(val,
                   withType: withType, typeKey: typeKey)));
-      setNonNullableValue(
-          ret,
-          "map",
-          mapMaker<String, String>(
-              model.map, (String key) => key, (String value) => value));
-      setNonNullableValue(
+      setNullableValue(ret, "map",
+          nullableMapMaker<String>(model.map, (String value) => value));
+      setNullableValue(
           ret,
           "mapMap",
-          mapMaker<String, Map<String, String>>(
+          nullableMapMaker<Map<String, String>>(
               model.mapMap,
-              (String key) => key,
-              (Map<String, String> value) => mapMaker<String, String>(
-                  value, (String key) => key, (String value) => value)));
-      setNonNullableValue(
+              (Map<String, String> value) =>
+                  nullableMapMaker<String>(value, (String value) => value)));
+      setNullableValue(
           ret,
           "mapBook",
-          mapMaker<String, Book>(
+          nullableMapMaker<Book>(
               model.mapBook,
-              (String key) => key,
               (Book value) => _bookViewSerializer.toMap(value,
                   withType: withType, typeKey: typeKey)));
       setTypeKeyValue(typeKey, modelString(), withType, ret);
@@ -71,17 +66,15 @@ abstract class _$UserViewSerializer implements Serializer<User> {
     model.dob = _dateTimeSerializer.deserialize(map["DoB"]);
     model.book = _bookViewSerializer.fromMap(map["Book"], typeKey: typeKey);
     model.listStr =
-        safeIterableMapper<String>(map["listStr"], (String val) => val);
-    model.listBook = safeIterableMapper<Map>(map["listBook"],
+        nullableIterableMapper<String>(map["listStr"], (String val) => val);
+    model.listBook = nullableIterableMapper<Map>(map["listBook"],
         (Map val) => _bookViewSerializer.fromMap(val, typeKey: typeKey));
-    model.map = mapMaker<String, String>(
-        map["map"], (String key) => key, (String value) => value);
-    model.mapMap = mapMaker<String, Map<String, String>>(
+    model.map = nullableMapMaker<String>(map["map"], (String value) => value);
+    model.mapMap = nullableMapMaker<Map<String, String>>(
         map["mapMap"],
-        (String key) => key,
-        (Map<String, String> value) => mapMaker<String, String>(
-            value, (String key) => key, (String value) => value));
-    model.mapBook = mapMaker<String, Map>(map["mapBook"], (String key) => key,
+        (Map<String, String> value) =>
+            nullableMapMaker<String>(value, (String value) => value));
+    model.mapBook = nullableMapMaker<Map>(map["mapBook"],
         (Map value) => _bookViewSerializer.fromMap(value, typeKey: typeKey));
     return model;
   }

--- a/example/user/user/user_mongo.g.dart
+++ b/example/user/user/user_mongo.g.dart
@@ -15,46 +15,41 @@ abstract class _$UserMongoSerializer implements Serializer<User> {
     Map<String, dynamic> ret;
     if (model != null) {
       ret = <String, dynamic>{};
-      setNonNullableValue(ret, "_id", _mongoId.serialize(model.id));
-      setNonNullableValue(ret, "email", model.email);
-      setNonNullableValue(ret, "N", model.name);
-      setNonNullableValue(ret, "dob", _dateTimeSerializer.serialize(model.dob));
-      setNonNullableValue(
+      setNullableValue(ret, "_id", _mongoId.serialize(model.id));
+      setNullableValue(ret, "email", model.email);
+      setNullableValue(ret, "N", model.name);
+      setNullableValue(ret, "dob", _dateTimeSerializer.serialize(model.dob));
+      setNullableValue(
           ret,
           "book",
           _bookMongoSerializer.toMap(model.book,
               withType: withType, typeKey: typeKey));
-      setNonNullableValue(ret, "listStr",
-          safeIterableMapper<String>(model.listStr, (String val) => val));
-      setNonNullableValue(
+      setNullableValue(ret, "listStr",
+          nullableIterableMapper<String>(model.listStr, (String val) => val));
+      setNullableValue(
           ret,
           "listBook",
-          safeIterableMapper<Book>(
+          nullableIterableMapper<Book>(
               model.listBook,
               (Book val) => _bookMongoSerializer.toMap(val,
                   withType: withType, typeKey: typeKey)));
-      setNonNullableValue(
-          ret,
-          "map",
-          mapMaker<String, String>(
-              model.map, (String key) => key, (String value) => value));
-      setNonNullableValue(
+      setNullableValue(ret, "map",
+          nullableMapMaker<String>(model.map, (String value) => value));
+      setNullableValue(
           ret,
           "mapMap",
-          mapMaker<String, Map<String, String>>(
+          nullableMapMaker<Map<String, String>>(
               model.mapMap,
-              (String key) => key,
-              (Map<String, String> value) => mapMaker<String, String>(
-                  value, (String key) => key, (String value) => value)));
-      setNonNullableValue(
+              (Map<String, String> value) =>
+                  nullableMapMaker<String>(value, (String value) => value)));
+      setNullableValue(
           ret,
           "mapBook",
-          mapMaker<String, Book>(
+          nullableMapMaker<Book>(
               model.mapBook,
-              (String key) => key,
               (Book value) => _bookMongoSerializer.toMap(value,
                   withType: withType, typeKey: typeKey)));
-      setNonNullableValue(ret, "password", model.password);
+      setNullableValue(ret, "password", model.password);
       setTypeKeyValue(typeKey, modelString(), withType, ret);
     }
     return ret;
@@ -73,17 +68,15 @@ abstract class _$UserMongoSerializer implements Serializer<User> {
     model.dob = _dateTimeSerializer.deserialize(map["dob"]);
     model.book = _bookMongoSerializer.fromMap(map["book"], typeKey: typeKey);
     model.listStr =
-        safeIterableMapper<String>(map["listStr"], (String val) => val);
-    model.listBook = safeIterableMapper<Map>(map["listBook"],
+        nullableIterableMapper<String>(map["listStr"], (String val) => val);
+    model.listBook = nullableIterableMapper<Map>(map["listBook"],
         (Map val) => _bookMongoSerializer.fromMap(val, typeKey: typeKey));
-    model.map = mapMaker<String, String>(
-        map["map"], (String key) => key, (String value) => value);
-    model.mapMap = mapMaker<String, Map<String, String>>(
+    model.map = nullableMapMaker<String>(map["map"], (String value) => value);
+    model.mapMap = nullableMapMaker<Map<String, String>>(
         map["mapMap"],
-        (String key) => key,
-        (Map<String, String> value) => mapMaker<String, String>(
-            value, (String key) => key, (String value) => value));
-    model.mapBook = mapMaker<String, Map>(map["mapBook"], (String key) => key,
+        (Map<String, String> value) =>
+            nullableMapMaker<String>(value, (String value) => value));
+    model.mapBook = nullableMapMaker<Map>(map["mapBook"],
         (Map value) => _bookMongoSerializer.fromMap(value, typeKey: typeKey));
     model.password = map["password"];
     return model;

--- a/lib/src/annotations/annotations.dart
+++ b/lib/src/annotations/annotations.dart
@@ -8,9 +8,9 @@ class GenSerializer {
   /// Supply optional modelName
   final String modelName;
 
-  /// Should fields be included by default?
+  /// Should all fields be included by default?
   ///
-  /// Defaults to [true]
+  /// Default to [true]
   final bool includeByDefault;
 
   /// Specify whether a property could be encoded, only, decoded only or both
@@ -22,7 +22,9 @@ class GenSerializer {
   /// Supplies [Serializer]s to use when unknown PODO type is encountered
   final List<Type> serializers;
 
-  /// Enable null check on fields
+  /// Enable null check on fields if false
+  ///
+  /// Default to [true]
   final bool nullableFields;
 
   const GenSerializer(
@@ -31,7 +33,7 @@ class GenSerializer {
       this.serializers: const <Type>[],
       this.modelName,
       this.includeByDefault: true,
-      this.nullableFields: false});
+      this.nullableFields: true});
 }
 
 class Property<T> {
@@ -114,6 +116,28 @@ class EnDecode<T> extends Property<T> {
 /// Annotation to ignore a field while encoding or decoding
 class Ignore extends EnDecode {
   const Ignore();
+}
+
+/// Annotation used to request encoding and decoding of a field in model
+/// shortcup for `const EnDecode(alias: "key")`
+/// become `const Alias("key")`
+class Alias<T> extends Property<T> {
+  /// Optional. Key used to decode and encode the model from and to the [Map]
+  final String alias;
+  final FieldProcessor<T, dynamic> processor;
+  final bool isNullable;
+  final T defaultsTo;
+  final String encodeTo;
+  final String decodeFrom;
+  final bool valueFromConstructor;
+
+  const Alias(this.alias,
+      {this.isNullable,
+      this.defaultsTo,
+      this.processor,
+      this.valueFromConstructor})
+      : encodeTo = alias,
+        decodeFrom = alias;
 }
 
 const ignore = const Ignore();

--- a/lib/src/serializer/utils.dart
+++ b/lib/src/serializer/utils.dart
@@ -3,17 +3,21 @@ import 'repo.dart';
 typedef String KeyMaker<Key>(Key key);
 typedef dynamic ValueMaker<Value>(Value value);
 
-Map<String, dynamic> mapMaker<Key, Value>(
-    Map map, KeyMaker<Key> keyMaker, ValueMaker<Value> valueMaker) {
+Map<String, dynamic> nullableMapMaker<Value>(
+    Map<String, dynamic> map, ValueMaker<Value> valueMaker) {
   Map<String, dynamic> ret;
   if (map != null) {
     ret = <String, dynamic>{};
-    map.forEach((key, value) {
-      ret[keyMaker(key)] = valueMaker(value);
-    });
+    for (final key in map.keys) {
+      ret[key] = valueMaker(map[key]);
+    }
   }
   return ret;
 }
+
+Map<String, dynamic> nonNullableMapMaker<Value>(Map<String, dynamic> map,
+        ValueMaker<Value> valueMaker, Map<String, dynamic> defaultValues) =>
+    nullableMapMaker<Value>(map, valueMaker) ?? defaultValues;
 
 void setNullableValue(Map<String, dynamic> map, String key, value) {
   map[key] = value;
@@ -21,17 +25,16 @@ void setNullableValue(Map<String, dynamic> map, String key, value) {
 
 void setNonNullableValue(Map<String, dynamic> map, String key, value) {
   if (value != null) {
-    map[key] = value;
+    setNullableValue(map, key, value);
   }
 }
 
-List safeIterableMapper<T>(Iterable<T> values, callback(T value)) =>
-    values?.map((T value) {
-      if (value == null) {
-        return null;
-      }
-      return callback(value);
-    })?.toList();
+List nullableIterableMapper<T>(Iterable<T> values, callback(T value)) =>
+    values?.map(callback)?.toList();
+
+List nonNullableIterableMapper<T>(
+        Iterable<T> values, callback(T value), List<T> defaultValues) =>
+    nullableIterableMapper<T>(values, callback) ?? defaultValues;
 
 void setTypeKeyValue(String typeKey, String modelString, bool withType,
     Map<String, dynamic> map) {


### PR DESCRIPTION
- fix processor inside List/Map (https://github.com/Jaguar-dart/jaguar_serializer/issues/73)

- All Serializers are now nullable by default to match `json_serializable` and produce faster code at first.

- Drop Map key processor, Only `Map<String, dynamic>` can be encode, not possible to encode a Map<int, String>, Map<Model, String> for exemple, let me know if you have use case on this, but I dont think it is important.

- `toMap(null)` return null
- `fromMap(null)` return null
- `fromMap({})` return object

also fix https://github.com/Jaguar-dart/jaguar_serializer_cli/issues/5