### PR TITLE
field format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.0.0-dev4
+
+- introduce field format to automatically convert field
+  Example:
+
+  ```dart
+  class Model {  
+    String myField;
+  }
+  @GenSerializer(fieldFormat: FieldFormat.snakeCase)
+  class ModelSerializer extends Serializer ... {}
+  
+  final map = { 'my_field': 'foo' };
+  final model = serializer.fromMap(map);
+  print(model.myField); // print 'foo'
+  ```
+
 ## 1.0.0-dev3
 
 - we now support final field deserialization

--- a/example/basic/basic_main.dart
+++ b/example/basic/basic_main.dart
@@ -1,12 +1,14 @@
 library example.player;
 
+import 'dart:convert';
+
 import 'package:jaguar_serializer/jaguar_serializer.dart';
 
 part 'basic_main.g.dart';
 
 @GenSerializer(serializers: const [
   AddressSerializer,
-])
+], fieldFormat: FieldFormat.snakeCase)
 class PlayerSerializer extends Serializer<Player> with _$PlayerSerializer {}
 
 @GenSerializer()
@@ -46,28 +48,31 @@ class Address {
 }
 
 void json() {
-  SerializerRepo serializer = new JsonRepo();
+  SerializerRepo serializer =
+      new JsonRepo(serializers: [new PlayerSerializer()]);
   {
-    Player player = serializer.deserialize({
+    Player player = serializer.deserialize(JSON.encode({
       'name': 'John',
       'email': 'john@noemail.com',
       'age': 25,
       'score': 1000,
-      'emailConfirmed': true,
+      'email_confirmed': true,
       '@t': "Player"
-    });
+    }));
     // Player(John, john@noemail.com, 25, 1000, true)
     print(player);
   }
 
   {
-    Player player = serializer.deserialize({
-      'name': 'John',
-      'email': 'john@noemail.com',
-      'age': 25,
-      'score': 1000,
-      'emailConfirmed': true
-    }, type: Player);
+    Player player = serializer.deserialize(
+        JSON.encode({
+          'name': 'John',
+          'email': 'john@noemail.com',
+          'age': 25,
+          'score': 1000,
+          'email_confirmed': true
+        }),
+        type: Player);
     // Player(John, john@noemail.com, 25, 1000, true)
     print(player);
   }
@@ -86,7 +91,8 @@ void json() {
 }
 
 void yaml() {
-  SerializerRepo serializer = new YamlRepo();
+  SerializerRepo serializer =
+      new YamlRepo(serializers: [new PlayerSerializer()]);
   {
     Player player = serializer.deserialize({
       'name': 'John',
@@ -139,5 +145,5 @@ void main() {
   print(pSerializer.toMap(player, withType: true));
 
   json();
-  yaml();
+  //yaml();
 }

--- a/example/basic/basic_main.g.dart
+++ b/example/basic/basic_main.g.dart
@@ -17,7 +17,7 @@ abstract class _$PlayerSerializer implements Serializer<Player> {
       setNullableValue(ret, "email", model.email);
       setNullableValue(ret, "age", model.age);
       setNullableValue(ret, "score", model.score);
-      setNullableValue(ret, "emailConfirmed", model.emailConfirmed);
+      setNullableValue(ret, "email_confirmed", model.emailConfirmed);
       setNullableValue(ret, "test", model.test);
       setNullableValue(
           ret,
@@ -40,7 +40,7 @@ abstract class _$PlayerSerializer implements Serializer<Player> {
     model.email = map["email"];
     model.age = map["age"];
     model.score = map["score"];
-    model.emailConfirmed = map["emailConfirmed"];
+    model.emailConfirmed = map["email_confirmed"];
     model.test = map["test"];
     model.address =
         _addressSerializer.fromMap(map["address"], typeKey: typeKey);

--- a/lib/src/annotations/annotations.dart
+++ b/lib/src/annotations/annotations.dart
@@ -27,13 +27,32 @@ class GenSerializer {
   /// Default to [true]
   final bool nullableFields;
 
+  /// Determine the format for a field, [none] by default
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// class Model {
+  ///   String myField;
+  /// }
+  ///
+  /// @GenSerializer(fieldFormat: FieldFormat.snakeCase)
+  /// class ModelSerializer extends Serializer ... {}
+  ///
+  /// final map = { 'my_field': 'foo' };
+  /// final model = serializer.fromMap(map);
+  /// print(model.myField); // print 'foo'
+  /// ```
+  final FieldFormat fieldFormat;
+
   const GenSerializer(
       {this.fields: const <String, Property>{},
       this.ignore: const <String>[],
       this.serializers: const <Type>[],
       this.modelName,
       this.includeByDefault: true,
-      this.nullableFields: true});
+      this.nullableFields: true,
+      this.fieldFormat: FieldFormat.none});
 }
 
 class Property<T> {
@@ -145,3 +164,6 @@ const Property nullable = const Property(isNullable: true);
 const Property nonNullable = const Property(isNullable: false);
 const Property useConstructorForDefaultsValue =
     const Property(valueFromConstructor: true, isNullable: false);
+
+/// Determine the outpu format for a field
+enum FieldFormat { none, camelCase, snakeCase, kebabCase }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: jaguar_serializer
-version: 1.0.0-dev3
+version: 1.0.0-dev4
 description: Platform and format agnostic serializer built using source_gen
 authors:
 - Ravi Teja Gudapati <tejainece@gmail.com>


### PR DESCRIPTION
introduce field format

```dart
class FieldFormatTest {
  String fooBar = "42";
  int myField = 42;
}

@GenSerializer(fieldFormat: FieldFormat.snakeCase)
class FieldFormatTestSerializer extends Serializer<FieldFormatTest>
    with _$FieldFormatTestSerializer {}


// JSON
{
   "foo_bar": "42",
   "my_field": 42
}
```

The number of formating is limited for now because we do it at compile time.