### PR TITLE
fix for `bool cannot be null`exception

### DIFF
--- a/serializer_cli/lib/src/instantiater/instantiater.dart
+++ b/serializer_cli/lib/src/instantiater/instantiater.dart
@@ -192,9 +192,9 @@ class AnnotationParser {
       FieldProcessorInfo processor;
       if (annot != null) {
         dontEncode =
-            annot.getField('dontEncode').toBoolValue() ? true : dontEncode;
+            annot.getField('dontEncode').toBoolValue() ?? false ? true : dontEncode;
         dontDecode =
-            annot.getField('dontDecode').toBoolValue() ? true : dontDecode;
+            annot.getField('dontDecode').toBoolValue() ?? false ? true : dontDecode;
 
         encodeTo = annot.getField('encodeTo')?.toStringValue() ?? encodeTo;
         decodeFrom =


### PR DESCRIPTION
I got an bool cannot be null Exception the moment I did a Field() annotation. In my case I wanted to add a processor.

The source of the exception was the code in `instantiater.dart`  from line 195:

``` Dart
      String encodeTo = name;
      String decodeFrom = name;
      bool nullable = globalNullable;
      FieldProcessorInfo processor;
      if (annot != null) {
        dontEncode =
            annot.getField('dontEncode').toBoolValue() ? true : dontEncode;   <- here came the exception
        dontDecode =
            annot.getField('dontDecode').toBoolValue() ? true : dontDecode;

        encodeTo = annot.getField('encodeTo')?.toStringValue() ?? encodeTo;
        decodeFrom =
            annot.getField('decodeFrom')?.toStringValue() ?? decodeFrom;

        nullable = annot.getField('isNullable').toBoolValue() ?? nullable;
        processor = _parseFieldProcessor(annot.getField('processor'));
      }
```

I wonder how this could have worked in the last time at all because if `anno` did not contain `dontEncode` and  `dontEncode` you always would get this exception because
`null.toBoolValue == null`  my fix now is this here:

```Dart
      if (annot != null) {
        dontEncode =
            annot.getField('dontEncode').toBoolValue() ?? false ? true : dontEncode;
        dontDecode =
            annot.getField('dontDecode').toBoolValue() ?? false ? true : dontDecode;

        encodeTo = annot.getField('encodeTo')?.toStringValue() ?? encodeTo;
        decodeFrom =
            annot.getField('decodeFrom')?.toStringValue() ?? decodeFrom;
```

I guess this could made more readable if we give up some of the concise format.

Cheers
Thomas 